### PR TITLE
Safari support

### DIFF
--- a/jquery.ajaxprogress.js
+++ b/jquery.ajaxprogress.js
@@ -1,7 +1,7 @@
 /*!
  * jQuery ajaxProgress Plugin v0.5.0
  * Requires jQuery v1.5.0 or later
- * 
+ *
  * http://www.kpozin.net/ajaxprogress
  *
  * (c) 2011, Konstantin Pozin
@@ -51,7 +51,7 @@
 
 
     // We'll work with the original factory method just in case
-    var makeOriginalXhr = $.ajaxSettings.xhr.bind($.ajaxSettings);
+    var makeOriginalXhr = $.proxy($.ajaxSettings.xhr, $.ajaxSettings);
 
     // Options to be passed into $.ajaxSetup;
     var newOptions = {};

--- a/jquery.ajaxprogress.js
+++ b/jquery.ajaxprogress.js
@@ -66,7 +66,7 @@
         if (newXhr) {
             newXhr.addEventListener("progress", function(evt) {
                 handleOnProgress(evt, s);
-            });
+            }, false);
         }
         return newXhr;
     };


### PR DESCRIPTION
Safari does not support Function.prototype.bind yet, so I replaced it with $.proxy.

It works in Safari now :-)
